### PR TITLE
Fix deep merge params order. Make classification public. Skip abi dir…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "evmdecoder",
   "description": "Library to decode EVM contract data.",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "contributors": [
     "Splunk",
     "Jayson Jacobs"

--- a/src/abi/repo.ts
+++ b/src/abi/repo.ts
@@ -79,7 +79,7 @@ export class AbiRepository implements ManagedResource {
   public async initialize() {
     const config = this.config
     debug('Initializing ABI repository with config %O', config)
-    if (config.directory != null) {
+    if (config.directory?.length) {
       const abiCount = await this.loadAbisFromDir(config.directory!, config)
       info('Loaded %d ABIs from directory %s', abiCount, config.directory)
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,15 +70,15 @@ export class EvmDecoder {
   private config: Config
   private abortHandle: AbortHandle
   private abiRepo: AbiRepository
-  private classification: Classification
   private contractInfoCache: LRUCache<string, Promise<ContractInfo>>
   private resources: ManagedResource[] = []
   private waitAfterFailure: WaitTime
 
+  public classification: Classification
   public ethClient: EthereumClient
 
   constructor(config: DeepPartial<Config>) {
-    this.config = deepMerge(config, DEFAULT_CONFIG) as Config
+    this.config = deepMerge(DEFAULT_CONFIG, config) as Config
     this.abortHandle = new AbortHandle()
     this.waitAfterFailure = exponentialBackoff({ min: 0, max: this.config.eth.client.maxRetryTime })
     this.abiRepo = new AbiRepository(this.config.abi)

--- a/src/utils/obj.ts
+++ b/src/utils/obj.ts
@@ -1,4 +1,4 @@
-export function removeEmtpyValues<R extends { [k: string]: any }, I extends { [P in keyof R]: any | null | undefined }>(
+export function removeEmptyValues<R extends { [k: string]: any }, I extends { [P in keyof R]: any | null | undefined }>(
   obj: I
 ): R {
   return Object.fromEntries(Object.entries(obj).filter(([, v]) => v != null)) as R
@@ -6,7 +6,7 @@ export function removeEmtpyValues<R extends { [k: string]: any }, I extends { [P
 
 export function prefixKeys<T extends { [k: string]: any }>(obj: T, prefix?: string | null, removeEmpty?: boolean): T {
   if (prefix == null || prefix === '') {
-    return removeEmpty ? removeEmtpyValues(obj) : obj
+    return removeEmpty ? removeEmptyValues(obj) : obj
   }
   const entries = Object.entries(obj)
   return Object.fromEntries(
@@ -16,7 +16,7 @@ export function prefixKeys<T extends { [k: string]: any }>(obj: T, prefix?: stri
 
 /**
  * Recursively (deeply) merges 2 object of the same type. It only merges plain object, not arrays.
- * It does not mutate the original object but may return references to (parts of the) orginal object.
+ * It does not mutate the original object but may return references to (parts of the) original object.
  */
 export function deepMerge<T extends { [k: string]: any }>(a: T, b: T): T {
   return Object.fromEntries([

--- a/test/utils/obj.test.ts
+++ b/test/utils/obj.test.ts
@@ -1,4 +1,4 @@
-import { deepMerge, removeEmtpyValues, prefixKeys } from '../../src/utils/obj'
+import { deepMerge, removeEmptyValues, prefixKeys } from '../../src/utils/obj'
 
 test('deepMerge', () => {
   expect(deepMerge({ a: 'foo' }, { a: 'bar' })).toMatchInlineSnapshot(`
@@ -39,7 +39,7 @@ test('deepMerge', () => {
     `)
 })
 
-test('removeEmtpyValues', () => {
+test('removeEmptyValues', () => {
   expect({ a: undefined, foo: null, yo: 'yo' }).toMatchInlineSnapshot(`
         Object {
           "a": undefined,
@@ -47,7 +47,7 @@ test('removeEmtpyValues', () => {
           "yo": "yo",
         }
     `)
-  expect(removeEmtpyValues({ a: undefined, foo: null, yo: 'yo' })).toMatchInlineSnapshot(`
+  expect(removeEmptyValues({ a: undefined, foo: null, yo: 'yo' })).toMatchInlineSnapshot(`
         Object {
           "yo": "yo",
         }


### PR DESCRIPTION
…ectory initialization on null, undefined, or empty string.