### PR TITLE
don't require getting data from a node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "evmdecoder",
   "description": "Library to decode EVM contract data.",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "contributors": [
     "Splunk",
     "Jayson Jacobs"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "evmdecoder",
   "description": "Library to decode EVM contract data.",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "contributors": [
     "Splunk",
     "Jayson Jacobs"

--- a/src/abi/contract.ts
+++ b/src/abi/contract.ts
@@ -133,10 +133,6 @@ export function computeContractFingerprint(
 export async function getContractInfo(
   address: Address,
   resources: ContractResources
-  // ethClient: EthereumClient,
-  // classification: Classification,
-  // signatureMatcher?: SignatureMatcher,
-  // contractNameLookup?: ContractNameLookup
 ): Promise<ContractInfo> {
   const { ethClient, classification, abiRepo } = resources
   const signatureMatcher: SignatureMatcher = (sig: string) => abiRepo.getMatchingSignature(sig)

--- a/src/abi/contract.ts
+++ b/src/abi/contract.ts
@@ -1,9 +1,9 @@
 import { createModuleDebug, TRACE_ENABLED } from '@splunkdlt/debug-logging'
-import { cachedAsync, Cache, NoopCache } from '@splunkdlt/cache'
+import { cachedAsync, Cache, NoopCache, LRUCache } from '@splunkdlt/cache'
 import { EthereumClient } from '../eth/client'
 import { getCode } from '../eth/requests'
 import { sha3 } from './wasm'
-import { Classification } from '../utils/classification'
+import { Classification, ClassificationResources, ContractProperties } from '../utils/classification'
 import { AbiRepository } from './repo'
 
 const { info, debug, trace, warn } = createModuleDebug('abi:contract')
@@ -49,6 +49,17 @@ export interface ERC3668Properties {
   url: string
 }
 
+export interface TokenPairInfo {
+  address: string
+  info?: ContractInfo
+}
+
+export interface TokenPair {
+  type: string
+  token0?: TokenPairInfo
+  token1?: TokenPairInfo
+}
+
 export interface ContractInfo {
   /** True if the corresponding account is a smart contract, otherwise false */
   isContract: boolean
@@ -59,7 +70,7 @@ export interface ContractInfo {
   /** Type of contract from signature matching */
   contractType?: ContractType
   /** Token properties (if ERC20, ERC721, ERC777, ERC1155) */
-  properties?: TokenProperties | MultiSigProperties | ERC3668Properties
+  properties?: Partial<ContractProperties>
 }
 
 /** Lookup function to find matching signature for a hash */
@@ -67,6 +78,10 @@ export type SignatureMatcher = (sig: string, address?: Address) => string | unde
 
 /** Lookup function to find name for a given contract address or fingerprint */
 export type ContractNameLookup = (address: Address, fingerprint: string) => string | undefined
+
+export interface ContractResources extends ClassificationResources {
+  classification: Classification
+}
 
 /**
  * Find function and event signature hashes in the EVM bytecode and attempt to match them against
@@ -117,11 +132,16 @@ export function computeContractFingerprint(
  */
 export async function getContractInfo(
   address: Address,
-  ethClient: EthereumClient,
-  classification: Classification,
-  signatureMatcher?: SignatureMatcher,
-  contractNameLookup?: ContractNameLookup
+  resources: ContractResources
+  // ethClient: EthereumClient,
+  // classification: Classification,
+  // signatureMatcher?: SignatureMatcher,
+  // contractNameLookup?: ContractNameLookup
 ): Promise<ContractInfo> {
+  const { ethClient, classification, abiRepo } = resources
+  const signatureMatcher: SignatureMatcher = (sig: string) => abiRepo.getMatchingSignature(sig)
+  const contractNameLookup = (address: string, fingerprint: string) =>
+    abiRepo.getContractByAddress(address)?.contractName ?? abiRepo.getContractByFingerprint(fingerprint)?.contractName
   debug('Retrieving contract information for address %s', address)
   if (signatureMatcher == null) {
     return { isContract: true }
@@ -137,7 +157,7 @@ export async function getContractInfo(
   }
   const contractName =
     fingerprint != null && contractNameLookup != null ? contractNameLookup(address, fingerprint) : undefined
-  const contractType = await classification.classifyContract(address, code)
+  const contractType = await classification.classifyContract({ address, code })
   const properties = await getContractProperties(classification, contractType, address)
   return {
     isContract: true,
@@ -152,15 +172,17 @@ async function getContractProperties(
   classification: Classification,
   contractType: ContractType,
   address: string
-): Promise<TokenProperties | MultiSigProperties | ERC3668Properties | undefined> {
+): Promise<Partial<ContractProperties> | undefined> {
   const isGnosis = contractType.name != null ? contractType.name.includes('Gnosis') : false
-  if (contractType.standards != null || isGnosis) {
+  const isTokenPair = contractType.name === 'TokenPair'
+  if (contractType.standards != null || isGnosis || isTokenPair) {
     // const target = (Array.isArray(contractType.proxies) && !isGnosis)
     //     ? contractType.proxies[contractType.proxies.length -1].target
     //     : address;
     const target = address
     if (target != null) {
       try {
+        console.log('getting contract properties')
         const properties = await classification.getContractProperties(target, contractType)
         return properties
       } catch (e) {
@@ -173,29 +195,19 @@ async function getContractProperties(
 
 export async function contractInfo({
   address,
-  ethBatchClient,
-  abiRepo,
-  contractInfoCache = new NoopCache(),
-  classification
+  resources
 }: {
   address: Address
-  ethBatchClient: EthereumClient
-  abiRepo: AbiRepository
-  contractInfoCache: Cache<string, Promise<ContractInfo>>
-  classification: Classification
+  resources: ContractResources
 }): Promise<ContractInfo | undefined> {
+  const { ethClient, abiRepo, contractInfoCache, classification } = resources
   if (abiRepo == null) {
     return
   }
   const result = await cachedAsync(address, contractInfoCache, (addr: Address) =>
     getContractInfo(
       addr,
-      ethBatchClient,
-      classification,
-      (sig: string) => abiRepo.getMatchingSignature(sig),
-      (address: string, fingerprint: string) =>
-        abiRepo.getContractByAddress(address)?.contractName ??
-        abiRepo.getContractByFingerprint(fingerprint)?.contractName
+      resources
     )
   )
   return result

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,276 +67,276 @@ interface FormattedTransactionResponse {
 const addressInfo = (contractInfo?: ContractInfo): ContractInfo | undefined => contractInfo ?? undefined
 
 export class EvmDecoder {
-         private config: Config
-         private abortHandle: AbortHandle
-         private abiRepo: AbiRepository
-         private contractInfoCache: LRUCache<string, Promise<ContractInfo>>
-         private resources: ManagedResource[] = []
-         private waitAfterFailure: WaitTime
+  private config: Config
+  private abortHandle: AbortHandle
+  private abiRepo: AbiRepository
+  private contractInfoCache: LRUCache<string, Promise<ContractInfo>>
+  private resources: ManagedResource[] = []
+  private waitAfterFailure: WaitTime
 
-         public classification: Classification
-         public ethClient: EthereumClient
+  public classification: Classification
+  public ethClient: EthereumClient
 
-         constructor(config: DeepPartial<Config>) {
-           this.config = deepMerge(DEFAULT_CONFIG, config) as Config
-           this.abortHandle = new AbortHandle()
-           this.waitAfterFailure = exponentialBackoff({ min: 0, max: this.config.eth.client.maxRetryTime })
-           this.abiRepo = new AbiRepository(this.config.abi)
-           this.addResource(this.abiRepo)
+  constructor(config: DeepPartial<Config>) {
+    this.config = deepMerge(DEFAULT_CONFIG, config) as Config
+    this.abortHandle = new AbortHandle()
+    this.waitAfterFailure = exponentialBackoff({ min: 0, max: this.config.eth.client.maxRetryTime })
+    this.abiRepo = new AbiRepository(this.config.abi)
+    this.addResource(this.abiRepo)
 
-           this.contractInfoCache = new LRUCache<string, Promise<ContractInfo>>({
-             maxSize: this.config.contractInfo.maxCacheEntries
-           })
-           const transport = new HttpTransport(this.config.eth.url, this.config.eth.http)
-           this.ethClient =
-             this.config.eth.client.maxBatchSize > 1
-               ? new BatchedEthereumClient(transport, {
-                   maxBatchSize: this.config.eth.client.maxBatchSize,
-                   maxBatchTime: this.config.eth.client.maxBatchTime
-                 })
-               : new EthereumClient(transport)
-           this.classification = new Classification(new EthereumClient(transport))
-         }
+    this.contractInfoCache = new LRUCache<string, Promise<ContractInfo>>({
+      maxSize: this.config.contractInfo.maxCacheEntries
+    })
+    const transport = new HttpTransport(this.config.eth.url, this.config.eth.http)
+    this.ethClient =
+      this.config.eth.client.maxBatchSize > 1
+        ? new BatchedEthereumClient(transport, {
+            maxBatchSize: this.config.eth.client.maxBatchSize,
+            maxBatchTime: this.config.eth.client.maxBatchTime
+          })
+        : new EthereumClient(transport)
+    this.classification = new Classification(new EthereumClient(transport))
+  }
 
-         public async initialize() {
-           await this.abiRepo.initialize()
-         }
+  public async initialize() {
+    await this.abiRepo.initialize()
+  }
 
-         public async decodeFunctionCall({ input, address }: { input: string; address?: string }) {
-           const contractInfo = address != null ? await this.contractInfo({ address }) : undefined
-           const decoded = this.abiRepo.decodeFunctionCall(input, {
-             contractAddress: address,
-             contractFingerprint: contractInfo != null ? contractInfo.fingerprint : undefined
-           })
-           if (address != null && decoded != null && contractInfo != null) {
-             try {
-               return this.classification.getExtraData(address, decoded, contractInfo, input)
-             } catch (e) {
-               warn('could not get extra data for transaction')
-             }
-           }
-           return decoded
-         }
+  public async decodeFunctionCall({ input, address }: { input: string; address?: string }) {
+    const contractInfo = address != null ? await this.contractInfo({ address }) : undefined
+    const decoded = this.abiRepo.decodeFunctionCall(input, {
+      contractAddress: address,
+      contractFingerprint: contractInfo != null ? contractInfo.fingerprint : undefined
+    })
+    if (address != null && decoded != null && contractInfo != null) {
+      try {
+        return this.classification.getExtraData(address, decoded, contractInfo, input)
+      } catch (e) {
+        warn('could not get extra data for transaction')
+      }
+    }
+    return decoded
+  }
 
-         public async contractInfo({ address }: { address: string }) {
-           return contractInfo({
-             address,
-             ethBatchClient: this.ethClient,
-             abiRepo: this.abiRepo,
-             contractInfoCache: this.contractInfoCache,
-             classification: this.classification
-           })
-         }
+  public async contractInfo({ address }: { address: string }) {
+    return contractInfo({
+      address,
+      ethBatchClient: this.ethClient,
+      abiRepo: this.abiRepo,
+      contractInfoCache: this.contractInfoCache,
+      classification: this.classification
+    })
+  }
 
-         public async getBlock(blockNumber: number): Promise<FullBlockResponse> {
-           const block = await this.ethClient.request(getBlock(blockNumber))
-           return await this.processBlock(block)
-         }
+  public async getBlock(blockNumber: number): Promise<FullBlockResponse> {
+    const block = await this.ethClient.request(getBlock(blockNumber))
+    return await this.processBlock(block)
+  }
 
-         public async getBlocks(blockNumbers: number[]): Promise<FullBlockResponse[]> {
-           const blocks = await this.ethClient
-             .requestBatch(blockNumbers.map(blockNumber => getBlock(blockNumber)))
-             .catch(e =>
-               Promise.reject(new Error(`Failed to request batch of blocks ${blockNumbers.join(', ')}: ${e}`))
-             )
+  public async getBlocks(blockNumbers: number[]): Promise<FullBlockResponse[]> {
+    const blocks = await this.ethClient
+      .requestBatch(blockNumbers.map(blockNumber => getBlock(blockNumber)))
+      .catch(e =>
+        Promise.reject(new Error(`Failed to request batch of blocks ${blockNumbers.join(', ')}: ${e}`))
+      )
 
-           return await Promise.all(blocks.map(b => this.processBlock(b)))
-         }
+    return await Promise.all(blocks.map(b => this.processBlock(b)))
+  }
 
-         public async getPendingTransaction(hash: string): Promise<FormattedPendingTransaction | undefined> {
-          try {
-            const transaction = await this.ethClient.request(getTransaction(hash), { ignoreErrors: true })
-            return await this.processPendingTransaction(transaction)
-          } catch (e) {
-            return undefined
-          }
-         }
+  public async getPendingTransaction(hash: string): Promise<FormattedPendingTransaction | undefined> {
+    try {
+      const transaction = await this.ethClient.request(getTransaction(hash), { ignoreErrors: true })
+      return await this.processPendingTransaction(transaction)
+    } catch (e) {
+      return undefined
+    }
+  }
 
-         public async getTransaction(hash: string): Promise<FormattedTransactionResponse> {
-          const transaction = await this.ethClient.request(getTransaction(hash))
-          return await this.processTransaction(transaction, true)
-         }
+  public async getTransaction(hash: string): Promise<FormattedTransactionResponse> {
+    const transaction = await this.ethClient.request(getTransaction(hash))
+    return await this.processTransaction(transaction, true)
+  }
 
-         public async getTransactionReceipt(hash: string): Promise<FormattedLogEvent[]> {
-           const receipt = await this.ethClient.request(getTransactionReceipt(hash))
-           if (receipt) {
-             return await Promise.all(
-               receipt?.logs?.map((l: RawLogResponse | RawParityLogResponse) => this.processTransactionLog(l)) ?? []
-             )
-           }
-           return []
-         }
+  public async getTransactionReceipt(hash: string): Promise<FormattedLogEvent[]> {
+    const receipt = await this.ethClient.request(getTransactionReceipt(hash))
+    if (receipt) {
+      return await Promise.all(
+        receipt?.logs?.map((l: RawLogResponse | RawParityLogResponse) => this.processTransactionLog(l)) ?? []
+      )
+    }
+    return []
+  }
 
-         private async processBlock(rawBlock: RawBlockResponse): Promise<FullBlockResponse> {
-           const block = formatBlock(rawBlock)
-           let receipts: RawParityTransactionReceipt[] = []
-           let individualReceipts = this.config.eth.client.individualReceipts
-           if (!individualReceipts) {
-             try {
-               receipts = await retry(() => this.ethClient.request(getBlockReceipts(block.number!)), {
-                 attempts: 3,
-                 waitBetween: this.waitAfterFailure,
-                 taskName: `getting receipts for block ${bigIntToNumber(block.number!)}`,
-                 abortHandle: this.abortHandle,
-                 warnOnError: true,
-                 onRetry: (attempt: number) =>
-                   warn('Retrying to get receipts for block %s (attempt %d)', bigIntToNumber(block.number!), attempt)
-               })
-             } catch (e) {
-               warn(
-                 'unable to get receipts for full block %d, switching to individualReceipts mode',
-                 bigIntToNumber(block.number!)
-               )
-               individualReceipts = true
-             }
-           }
+  private async processBlock(rawBlock: RawBlockResponse): Promise<FullBlockResponse> {
+    const block = formatBlock(rawBlock)
+    let receipts: RawParityTransactionReceipt[] = []
+    let individualReceipts = this.config.eth.client.individualReceipts
+    if (!individualReceipts) {
+      try {
+        receipts = await retry(() => this.ethClient.request(getBlockReceipts(block.number!)), {
+          attempts: 3,
+          waitBetween: this.waitAfterFailure,
+          taskName: `getting receipts for block ${bigIntToNumber(block.number!)}`,
+          abortHandle: this.abortHandle,
+          warnOnError: true,
+          onRetry: (attempt: number) =>
+            warn('Retrying to get receipts for block %s (attempt %d)', bigIntToNumber(block.number!), attempt)
+        })
+      } catch (e) {
+        warn(
+          'unable to get receipts for full block %d, switching to individualReceipts mode',
+          bigIntToNumber(block.number!)
+        )
+        individualReceipts = true
+      }
+    }
 
-           const transactions = await this.abortHandle.race(
-             Promise.all(
-               rawBlock.transactions.map(tx =>
-                 this.processTransaction(
-                   tx,
-                   individualReceipts,
-                   !individualReceipts
-                     ? receipts.filter(r => r.transactionHash === (tx as RawTransactionResponse).hash)[0]
-                     : undefined
-                 )
-               )
-             )
-           )
-           return {
-             block,
-             transactions
-           }
-         }
+    const transactions = await this.abortHandle.race(
+      Promise.all(
+        rawBlock.transactions.map(tx =>
+          this.processTransaction(
+            tx,
+            individualReceipts,
+            !individualReceipts
+              ? receipts.filter(r => r.transactionHash === (tx as RawTransactionResponse).hash)[0]
+              : undefined
+          )
+        )
+      )
+    )
+    return {
+      block,
+      transactions
+    }
+  }
 
-         private async processTransaction(
-           rawTx: RawTransactionResponse | string,
-           individualReceipts: boolean,
-           rawReceipt: RawParityTransactionReceipt | undefined = undefined
-         ): Promise<FormattedTransactionResponse> {
-           if (typeof rawTx === 'string') {
-             warn('Received raw transaction %s from block %d')
-             throw new RuntimeError(`Received raw transaction`)
-           }
+  private async processTransaction(
+    rawTx: RawTransactionResponse | string,
+    individualReceipts: boolean,
+    rawReceipt: RawParityTransactionReceipt | undefined = undefined
+  ): Promise<FormattedTransactionResponse> {
+    if (typeof rawTx === 'string') {
+      warn('Received raw transaction %s from block %d')
+      throw new RuntimeError(`Received raw transaction`)
+    }
 
-           const [receipt, toInfo, fromInfo] = await Promise.all([
-             individualReceipts ? this.ethClient.request(getTransactionReceipt(rawTx.hash)) : rawReceipt,
-             rawTx.to != null
-               ? contractInfo({
-                   address: rawTx.to,
-                   ethBatchClient: this.ethClient,
-                   abiRepo: this.abiRepo,
-                   contractInfoCache: this.contractInfoCache,
-                   classification: this.classification
-                 })
-               : undefined,
-             rawTx.from != null
-               ? contractInfo({
-                   address: rawTx.from,
-                   ethBatchClient: this.ethClient,
-                   abiRepo: this.abiRepo,
-                   contractInfoCache: this.contractInfoCache,
-                   classification: this.classification
-                 })
-               : undefined
-           ])
+    const [receipt, toInfo, fromInfo] = await Promise.all([
+      individualReceipts ? this.ethClient.request(getTransactionReceipt(rawTx.hash)) : rawReceipt,
+      rawTx.to != null
+        ? contractInfo({
+            address: rawTx.to,
+            ethBatchClient: this.ethClient,
+            abiRepo: this.abiRepo,
+            contractInfoCache: this.contractInfoCache,
+            classification: this.classification
+          })
+        : undefined,
+      rawTx.from != null
+        ? contractInfo({
+            address: rawTx.from,
+            ethBatchClient: this.ethClient,
+            abiRepo: this.abiRepo,
+            contractInfoCache: this.contractInfoCache,
+            classification: this.classification
+          })
+        : undefined
+    ])
 
-           const contractAddressInfo: ContractInfo | undefined =
-             receipt?.contractAddress != null
-               ? await contractInfo({
-                   address: receipt.contractAddress,
-                   ethBatchClient: this.ethClient,
-                   abiRepo: this.abiRepo,
-                   contractInfoCache: this.contractInfoCache,
-                   classification: this.classification
-                 })
-               : undefined
+    const contractAddressInfo: ContractInfo | undefined =
+      receipt?.contractAddress != null
+        ? await contractInfo({
+            address: receipt.contractAddress,
+            ethBatchClient: this.ethClient,
+            abiRepo: this.abiRepo,
+            contractInfoCache: this.contractInfoCache,
+            classification: this.classification
+          })
+        : undefined
 
-           const callInfo =
-             toInfo && toInfo.isContract
-               ? await this.decodeFunctionCall({ input: rawTx.input, address: rawTx.to! })
-               : undefined
+    const callInfo =
+      toInfo && toInfo.isContract
+        ? await this.decodeFunctionCall({ input: rawTx.input, address: rawTx.to! })
+        : undefined
 
-           const transaction = formatTransaction(
-             rawTx,
-             receipt!,
-             addressInfo(fromInfo),
-             addressInfo(toInfo),
-             addressInfo(contractAddressInfo),
-             callInfo
-           )
+    const transaction = formatTransaction(
+      rawTx,
+      receipt!,
+      addressInfo(fromInfo),
+      addressInfo(toInfo),
+      addressInfo(contractAddressInfo),
+      callInfo
+    )
 
-           const logEvents =
-             toInfo && toInfo.isContract
-               ? await Promise.all(
-                   receipt?.logs?.map((l: RawLogResponse | RawParityLogResponse) => this.processTransactionLog(l)) ?? []
-                 )
-               : []
+    const logEvents =
+      toInfo && toInfo.isContract
+        ? await Promise.all(
+            receipt?.logs?.map((l: RawLogResponse | RawParityLogResponse) => this.processTransactionLog(l)) ?? []
+          )
+        : []
 
-           return {
-             transaction,
-             logEvents
-           }
-         }
+    return {
+      transaction,
+      logEvents
+    }
+  }
 
-         private async processPendingTransaction(
-           rawTx: RawTransactionResponse | string
-         ): Promise<FormattedPendingTransaction> {
-           if (typeof rawTx === 'string') {
-             warn('Received raw transaction %s')
-             throw new RuntimeError(`Received raw transaction`)
-           }
+  private async processPendingTransaction(
+    rawTx: RawTransactionResponse | string
+  ): Promise<FormattedPendingTransaction> {
+    if (typeof rawTx === 'string') {
+      warn('Received raw transaction %s')
+      throw new RuntimeError(`Received raw transaction`)
+    }
 
-           const toInfo =
-             rawTx.to != null
-               ? await contractInfo({
-                   address: rawTx.to,
-                   ethBatchClient: this.ethClient,
-                   abiRepo: this.abiRepo,
-                   contractInfoCache: this.contractInfoCache,
-                   classification: this.classification
-                 })
-               : undefined
+    const toInfo =
+      rawTx.to != null
+        ? await contractInfo({
+            address: rawTx.to,
+            ethBatchClient: this.ethClient,
+            abiRepo: this.abiRepo,
+            contractInfoCache: this.contractInfoCache,
+            classification: this.classification
+          })
+        : undefined
 
-           const callInfo =
-             toInfo && toInfo.isContract
-               ? await this.decodeFunctionCall({ input: rawTx.input, address: rawTx.to! })
-               : undefined
+    const callInfo =
+      toInfo && toInfo.isContract
+        ? await this.decodeFunctionCall({ input: rawTx.input, address: rawTx.to! })
+        : undefined
 
-           return formatPendingTransaction(rawTx, 'pending', undefined, addressInfo(toInfo), callInfo)
-         }
+    return formatPendingTransaction(rawTx, 'pending', undefined, addressInfo(toInfo), callInfo)
+  }
 
-         private async processTransactionLog(evt: RawLogResponse | RawParityLogResponse): Promise<FormattedLogEvent> {
-           const eventContractInfo = await contractInfo({
-             address: evt.address,
-             ethBatchClient: this.ethClient,
-             abiRepo: this.abiRepo,
-             contractInfoCache: this.contractInfoCache,
-             classification: this.classification
-           })
+  public async processTransactionLog(evt: RawLogResponse | RawParityLogResponse): Promise<FormattedLogEvent> {
+    const eventContractInfo = await contractInfo({
+      address: evt.address,
+      ethBatchClient: this.ethClient,
+      abiRepo: this.abiRepo,
+      contractInfoCache: this.contractInfoCache,
+      classification: this.classification
+    })
 
-           const decodedEventData = this.abiRepo.decodeLogEvent(evt, {
-             contractAddress: evt.address,
-             contractFingerprint: eventContractInfo?.fingerprint
-           })
-           if (evt.address != null && decodedEventData != null && eventContractInfo != null) {
-             try {
-               const decodedExtra = await this.classification.getExtraData(
-                 evt.address,
-                 decodedEventData,
-                 eventContractInfo
-               )
-               return formatLogEvent(evt, addressInfo(eventContractInfo), decodedExtra)
-             } catch (e) {
-               warn('could not get extra data for transaction log')
-             }
-           }
-           return formatLogEvent(evt, addressInfo(eventContractInfo), decodedEventData)
-         }
+    const decodedEventData = this.abiRepo.decodeLogEvent(evt, {
+      contractAddress: evt.address,
+      contractFingerprint: eventContractInfo?.fingerprint
+    })
+    if (evt.address != null && decodedEventData != null && eventContractInfo != null) {
+      try {
+        const decodedExtra = await this.classification.getExtraData(
+          evt.address,
+          decodedEventData,
+          eventContractInfo
+        )
+        return formatLogEvent(evt, addressInfo(eventContractInfo), decodedExtra)
+      } catch (e) {
+        warn('could not get extra data for transaction log')
+      }
+    }
+    return formatLogEvent(evt, addressInfo(eventContractInfo), decodedEventData)
+  }
 
-         private addResource<R extends ManagedResource>(r: R): R {
-           this.resources.push(r)
-           return r
-         }
-       }
+  private addResource<R extends ManagedResource>(r: R): R {
+    this.resources.push(r)
+    return r
+  }
+}

--- a/src/utils/classification.ts
+++ b/src/utils/classification.ts
@@ -638,7 +638,6 @@ export class Classification {
     address: string,
     contractType: ContractType
   ): Promise<Partial<ContractProperties> | undefined> {
-    console.log(contractType.name, contractType.standards)
     const response: { [key: string]: any } = {
       type: ''
     }
@@ -691,10 +690,6 @@ export class Classification {
     if (contractType.name != null && contractType.name.includes('TokenPair')) {
       const type = contractType.name
       const { token0, token1 } = await this.getTokenPair(address)
-      // console.log('token0')
-      // console.log(token0)
-      // console.log('token1')
-      // console.log(token1)
       response.type = `${response.type} ${type}`.trim()
       response.token0 = token0
       response.token1 = token1


### PR DESCRIPTION
- instead of requiring data to be fetched from a node, allow users to pass data in.
- add token pair contract info when interacting with a contract that has `token0` and `token1` functions. like uniswap liquidity pool contracts.