### PR TITLE
fix recursive contract info error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "evmdecoder",
   "description": "Library to decode EVM contract data.",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "contributors": [
     "Splunk",
     "Jayson Jacobs"

--- a/src/abi/contract.ts
+++ b/src/abi/contract.ts
@@ -195,7 +195,7 @@ export async function contractInfo({
   address: Address
   resources: ContractResources
 }): Promise<ContractInfo | undefined> {
-  const { ethClient, abiRepo, contractInfoCache, classification } = resources
+  const { abiRepo, contractInfoCache } = resources
   if (abiRepo == null) {
     return
   }

--- a/src/abi/repo.ts
+++ b/src/abi/repo.ts
@@ -1,5 +1,5 @@
 import { join as joinPath } from 'path'
-import { AbiRepositoryConfig } from '../config'
+import { AbiRepositoryConfig, LogConfigSchema } from '../config'
 import { RawLogResponse } from '../eth/responses'
 import { createModuleDebug, TRACE_ENABLED } from '@splunkdlt/debug-logging'
 import { ManagedResource } from '@splunkdlt/managed-resource'
@@ -70,7 +70,7 @@ export class AbiRepository implements ManagedResource {
   private contractsByFingerprint: Map<string, ContractAbi> = new Map()
   private contractsByAddress: Map<string, ContractAbi> = new Map()
 
-  constructor(private config: AbiRepositoryConfig) {}
+  constructor(private config: AbiRepositoryConfig, private logging: LogConfigSchema) {}
 
   private addToSignatures(sig: string, abis: AbiItemDefinition[]) {
     const match = this.signatures.get(sig)
@@ -252,7 +252,9 @@ export class AbiRepository implements ManagedResource {
         if (matchingAbis!.anonymous) {
           debug('Failed to decode anonymous ABI', e)
         } else {
-          warn('Failed to decode ABI')
+          if (this.logging.showDecodeWarnings) {
+            warn('Failed to decode ABI')
+          }
         }
       }
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,8 @@ export interface Config {
   abi: AbiRepositoryConfig
   /** Contract info cache settings */
   contractInfo: ContractInfoConfigSchema
+  /** Log settings */
+  logging: LogConfigSchema
 }
 
 /** General Ethereum configuration including client and transport, defining how evmdecoder talks to the ethereum node */
@@ -58,6 +60,11 @@ export interface AbiRepositoryConfig {
 export interface ContractInfoConfigSchema {
   /** Maximum number of contract info results to cache in memory. Set to 0 to disable the cache. */
   maxCacheEntries: number
+}
+
+export interface LogConfigSchema {
+  showDecodeWarnings?: boolean
+  showClassificationWarnings?: boolean
 }
 
 export interface HttpTransportConfig {

--- a/src/eth/requests.ts
+++ b/src/eth/requests.ts
@@ -39,7 +39,7 @@ export function decodeResponseType(type: string, data: string): any {
     try {
       return web3.eth.abi.decodeParameter(type, data)
     } catch (e) {
-      warn('Failed to decode string response, trying hexToAscii')
+      debug('Failed to decode string response, trying hexToAscii')
       return web3.utils.hexToAscii(data).replace(/\u0000/g, '')
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,8 @@ const DEFAULT_CONFIG: DeepPartial<Config> = {
   },
   contractInfo: {
     maxCacheEntries: 25_000
-  }
+  },
+  logging: {}
 }
 
 interface FullBlockResponse {
@@ -82,7 +83,7 @@ export class EvmDecoder {
     this.config = deepMerge(DEFAULT_CONFIG, config) as Config
     this.abortHandle = new AbortHandle()
     this.waitAfterFailure = exponentialBackoff({ min: 0, max: this.config.eth.client.maxRetryTime })
-    this.abiRepo = new AbiRepository(this.config.abi)
+    this.abiRepo = new AbiRepository(this.config.abi, this.config.logging)
     this.addResource(this.abiRepo)
 
     this.contractInfoCache = new LRUCache<string, Promise<ContractInfo>>({
@@ -101,7 +102,7 @@ export class EvmDecoder {
       abiRepo: this.abiRepo,
       contractInfoCache: this.contractInfoCache
     }
-    this.classification = new Classification(classificationResources)
+    this.classification = new Classification(classificationResources, this.config.logging)
     this.contractResources =  {
       ethClient: this.ethClient,
       abiRepo: this.abiRepo,


### PR DESCRIPTION
- when a contract lists it's own address as `token0` or `token1` there was a recursion error. instead of recursively fetching a contract's info, we just return the address.
- add flags for annoying decode warnings