### PR TITLE
Fix socket timeout handling in HTTP transport agent

### DIFF
--- a/src/eth/http.ts
+++ b/src/eth/http.ts
@@ -38,7 +38,13 @@ export class HttpTransport implements EthereumTransport {
     this.config = { ...CONFIG_DEFAULTS, ...config }
     const baseAgentOptions: HttpOptions = {
       keepAlive: true,
-      maxSockets: 256
+      maxSockets: 256,
+      // Propagate the configured request timeout to agentkeepalive's active-socket
+      // inactivity timeout. Without this, agentkeepalive falls back to its default of
+      // max(freeSocketTimeout * 2, 8000) = 8000ms, which fires long before node-fetch's
+      // own `timeout` and destroys the socket (ERR_SOCKET_TIMEOUT) for slow responses
+      // such as large blocks with hundreds of transactions.
+      timeout: this.config.timeout
     }
     this.httpAgent = isHttps(url)
       ? new HttpsAgent({


### PR DESCRIPTION
## Summary
This change fixes a socket timeout issue in the HTTP transport layer by propagating the configured request timeout to the underlying `agentkeepalive` library's inactivity timeout setting.

## Key Changes
- Added `timeout` configuration to the `HttpAgent` and `HttpsAgent` options, passing through the configured request timeout value
- This ensures that the agent's socket inactivity timeout aligns with the application's configured request timeout, preventing premature socket destruction

## Implementation Details
Previously, `agentkeepalive` would fall back to its default inactivity timeout of `max(freeSocketTimeout * 2, 8000) = 8000ms` when no timeout was explicitly configured. This could cause sockets to be destroyed (with `ERR_SOCKET_TIMEOUT`) before the application's own request timeout was reached, particularly affecting slow responses such as large blocks with hundreds of transactions.

By explicitly setting the `timeout` option on the agent to match the configured request timeout, we ensure consistent timeout behavior across the entire request lifecycle.

https://claude.ai/code/session_01BEG3HfBuwNhijzL168Rkvv