### PR TITLE
fix(eth): persistent keep-alive connections and batch retry correctness

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "evmdecoder",
   "description": "Library to decode EVM contract data.",
-  "version": "0.0.70",
+  "version": "0.0.71",
   "contributors": [
     "Splunk",
     "Jayson Jacobs"

--- a/src/config.ts
+++ b/src/config.ts
@@ -78,6 +78,15 @@ export interface HttpTransportConfig {
   requestKeepAlive?: boolean
   /** Maximum number of sockets HEC will use (per host) */
   maxSockets?: number
+  /**
+   * How long (in milliseconds) idle keep-alive sockets are kept open before being
+   * destroyed. Determines how long the connection to the JSON RPC node survives
+   * between request bursts. agentkeepalive's own default is 4 seconds, which forces
+   * a fresh TCP connection after any short pause — that connection churn adds
+   * latency and can trip stateful middleboxes (NAT, firewalls, IDS) between the
+   * client and the node.
+   */
+  freeSocketTimeout?: Duration
   /** Maximum number of retries when a request fails */
   maxRetries: number
   /** Maximum number of times a batch request will be split if it fails (Error: batch request too large) */

--- a/src/eth/client.ts
+++ b/src/eth/client.ts
@@ -24,6 +24,9 @@ async function batchRequestWithFailover(
   if (splits < 1) {
     throw new RuntimeError(`batch request splits can't be less than 1`)
   }
+  if (reqs.length === 0) {
+    return []
+  }
   // const maxSplits = 10
   if (splits <= maxSplits) {
     if (splits > 1) {
@@ -155,7 +158,9 @@ export async function executeBatchRequest(
   transport: EthereumTransport,
   abortHandle: AbortHandle,
   httpConfig: HttpTransportConfig,
-  waitAfterFailure = linearBackoff({ min: 0, step: 2500, max: 120_000 }),
+  // min > 0: an instant retry lands on the same failing endpoint/connection state
+  // that just timed out and only amplifies the outage.
+  waitAfterFailure = linearBackoff({ min: 500, step: 2500, max: 120_000 }),
   attempt = 1
 ) {
   const maxAttempts = 5

--- a/src/eth/http.ts
+++ b/src/eth/http.ts
@@ -20,7 +20,8 @@ const CONFIG_DEFAULTS = {
   timeout: 60_000,
   validateCertificate: true,
   requestKeepAlive: true,
-  maxSockets: 256
+  maxSockets: 256,
+  freeSocketTimeout: 300_000
 }
 
 const initialCounters = {
@@ -38,13 +39,17 @@ export class HttpTransport implements EthereumTransport {
     this.config = { ...CONFIG_DEFAULTS, ...config }
     const baseAgentOptions: HttpOptions = {
       keepAlive: true,
-      maxSockets: 256,
+      maxSockets: this.config.maxSockets,
       // Propagate the configured request timeout to agentkeepalive's active-socket
       // inactivity timeout. Without this, agentkeepalive falls back to its default of
       // max(freeSocketTimeout * 2, 8000) = 8000ms, which fires long before node-fetch's
       // own `timeout` and destroys the socket (ERR_SOCKET_TIMEOUT) for slow responses
       // such as large blocks with hundreds of transactions.
-      timeout: this.config.timeout
+      timeout: this.config.timeout,
+      // Keep idle sockets alive long enough to be reused by the next burst of
+      // requests. agentkeepalive's 4s default destroys the connection after any
+      // short pause, forcing a fresh TCP connect per burst.
+      freeSocketTimeout: this.config.freeSocketTimeout
     }
     this.httpAgent = isHttps(url)
       ? new HttpsAgent({

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ const DEFAULT_CONFIG: DeepPartial<Config> = {
       validateCertificate: false,
       requestKeepAlive: true,
       maxSockets: 256,
+      freeSocketTimeout: 300_000,
       maxRetries: 10,
       maxBatchSplits: 15
     },

--- a/src/utils/obj.ts
+++ b/src/utils/obj.ts
@@ -34,12 +34,12 @@ export function isEmpty(obj: object): boolean {
   return obj == null || Object.values(obj).filter(v => v != null).length === 0
 }
 
+/** Splits `data` into chunks of at most `chunkSize` items. Does not mutate the input array. */
 export function chunkArray<T>(data: T[], chunkSize: number): T[][] {
-  const chunkCount = Math.ceil(data.length / chunkSize)
-  const chunks: any[][] = []
-  for (let i = 0; i < chunkCount; i++) {
-    const chunk = data.splice(0, chunkSize)
-    chunks.push(chunk)
+  const size = Number.isFinite(chunkSize) && chunkSize >= 1 ? Math.floor(chunkSize) : 1
+  const chunks: T[][] = []
+  for (let i = 0; i < data.length; i += size) {
+    chunks.push(data.slice(i, i + size))
   }
   return chunks
 }

--- a/test/abi/contract.test.ts
+++ b/test/abi/contract.test.ts
@@ -1,8 +1,10 @@
+import { LRUCache } from '@splunkdlt/cache'
 import { join } from 'path'
-import { computeContractFingerprint, extractFunctionsAndEvents } from '../../src/abi/contract'
+import { computeContractFingerprint, ContractInfo, extractFunctionsAndEvents } from '../../src/abi/contract'
 import { AbiRepository } from '../../src/abi/repo'
 import { readFile } from 'fs-extra'
 import { Classification } from '../../src/utils/classification'
+import { HttpTransportConfig } from '../../src/config'
 import { EthereumClient } from '../../src/eth/client'
 import { HttpTransport } from '../../src/eth/http'
 
@@ -14,7 +16,7 @@ test('extractFunctionsAndEvents', async () => {
     requireContractMatch: true,
     reconcileStructShapeFromTuples: false
   }
-  const abis = new AbiRepository(config)
+  const abis = new AbiRepository(config, {})
   await abis.loadAbiFile(join(__dirname, '../abis/BCB.json'), config)
   const fne = extractFunctionsAndEvents(
     await readFile(join(__dirname, '../fixtures/contract1.txt'), { encoding: 'utf-8' }),
@@ -65,7 +67,7 @@ test('extractFunctionsAndEvents BAYC', async () => {
     reconcileStructShapeFromTuples: false
   }
 
-  const abis = new AbiRepository(config)
+  const abis = new AbiRepository(config, {})
   await abis.loadAbiFile(join(__dirname, '../abis/ERC721.json'), config)
   const fne = extractFunctionsAndEvents(
     await readFile(join(__dirname, '../fixtures/bayc.txt'), { encoding: 'utf-8' }),
@@ -114,21 +116,29 @@ test('BAYC is classified as NFT', async () => {
     reconcileStructShapeFromTuples: false
   }
 
-  const abis = new AbiRepository(config)
+  const abis = new AbiRepository(config, {})
   await abis.loadAbiFile(join(__dirname, '../abis/ERC721.json'), config)
 
-  const transport = new HttpTransport('http://localhost:8545', {
+  const httpConfig: HttpTransportConfig = {
     timeout: 60_000,
     validateCertificate: false,
     requestKeepAlive: true,
-    maxSockets: 256
-  })
+    maxSockets: 256,
+    maxRetries: 10,
+    maxBatchSplits: 15
+  }
+  const transport = new HttpTransport('http://localhost:8545', httpConfig)
+  const ethClient = new EthereumClient(transport, httpConfig)
+  const contractInfoCache = new LRUCache<string, Promise<ContractInfo>>({ maxSize: 100 })
 
-  const classification = new Classification(new EthereumClient(transport))
+  const classification = new Classification({ ethClient, abiRepo: abis, contractInfoCache }, {})
   const baycCode = await readFile(join(__dirname, '../fixtures/bayc.txt'), { encoding: 'utf-8' })
 
   // console.log(classification.implementsErc721(baycCode))
-  const c = await classification.classifyContract('0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D', baycCode)
+  const c = await classification.classifyContract({
+    address: '0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D',
+    code: baycCode
+  })
   expect(c).toMatchInlineSnapshot(`
   Object {
     "baseUri": true,

--- a/test/abi/repo.test.ts
+++ b/test/abi/repo.test.ts
@@ -21,7 +21,7 @@ test('AbiRepository#decodeFunctionCall', async () => {
     searchRecursive: true,
     requireContractMatch: true,
     reconcileStructShapeFromTuples: false
-  })
+  }, {})
 
   await abiRepo.initialize()
 
@@ -129,7 +129,7 @@ test('AbiRepository#decodeLogEvent', async () => {
     searchRecursive: true,
     requireContractMatch: true,
     reconcileStructShapeFromTuples: false
-  })
+  }, {})
   await abiRepo.initialize()
 
   //console.log((abiRepo as any).signatures);
@@ -137,11 +137,6 @@ test('AbiRepository#decodeLogEvent', async () => {
   expect(
     abiRepo.decodeLogEvent(
       {
-        logIndex: '0x1',
-        blockNumber: '0x1bf',
-        blockHash: '0x16545b7f5052ebde2812b8ac8ad5d64da83e60bfe32c22f4e15a76f45b3acd47',
-        transactionHash: '0xb0d235d01b32b0f39e547117b5ec4f553dba0976e0b41ef58da1832c86de73f6',
-        transactionIndex: '0x0',
         address: '0xa0EB7CA45F646EA73F3d4F41eC197900A00CcdBf',
         data: '0x0000000000000000000000000000000000000000000000000429d069189e0000',
         topics: [
@@ -188,7 +183,7 @@ test('decode anonymous with collision', async () => {
     fingerprintContracts: false,
     requireContractMatch: true,
     reconcileStructShapeFromTuples: false
-  })
+  }, {})
   await abiRepo.initialize()
 
   expect(

--- a/test/utils/obj.test.ts
+++ b/test/utils/obj.test.ts
@@ -1,4 +1,4 @@
-import { deepMerge, removeEmptyValues, prefixKeys } from '../../src/utils/obj'
+import { chunkArray, deepMerge, removeEmptyValues, prefixKeys } from '../../src/utils/obj'
 
 test('deepMerge', () => {
   expect(deepMerge({ a: 'foo' }, { a: 'bar' })).toMatchInlineSnapshot(`
@@ -52,6 +52,32 @@ test('removeEmptyValues', () => {
           "yo": "yo",
         }
     `)
+})
+
+test('chunkArray', () => {
+  expect(chunkArray([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]])
+  expect(chunkArray([1, 2, 3], 3)).toEqual([[1, 2, 3]])
+  expect(chunkArray([1, 2, 3], 10)).toEqual([[1, 2, 3]])
+  expect(chunkArray([], 5)).toEqual([])
+})
+
+test('chunkArray does not mutate its input', () => {
+  // Regression test: chunkArray used to splice() items out of the caller's array,
+  // so retrying/splitting a batch with the same array sent zero requests and
+  // resolved with an empty (fake-success) response set.
+  const input = [1, 2, 3, 4, 5]
+  const first = chunkArray(input, 5)
+  expect(input).toEqual([1, 2, 3, 4, 5])
+  expect(first).toEqual([[1, 2, 3, 4, 5]])
+  // simulate the batch-split retry: same array, more splits
+  const second = chunkArray(input, 3)
+  expect(second).toEqual([[1, 2, 3], [4, 5]])
+  expect(input).toEqual([1, 2, 3, 4, 5])
+})
+
+test('chunkArray clamps invalid chunk sizes', () => {
+  expect(chunkArray([1, 2], 0)).toEqual([[1], [2]])
+  expect(chunkArray([1, 2], NaN)).toEqual([[1], [2]])
 })
 
 test('prefixKeys', () => {


### PR DESCRIPTION
## Context

agentindex-api's mainnet catch-up sync collapsed to ~1 block per 5 minutes. Root cause analysis showed new TCP connections from the scanner's container to the reth node being SYN-black-holed in multi-minute windows by a stateful network hop, while **established** connections stayed LAN-fast (whole blocks processed in ~70ms once a connection was warm). Verified with an in-container curl loop: fresh connections failed with `Couldn't connect to server after ~134s` (kernel SYN-retry exhaustion) in windows, then nine consecutive fresh connections completed in ~10ms.

evmdecoder amplified this into a permanent death spiral: the keep-alive agent destroyed idle sockets after **4 seconds** (agentkeepalive default — `freeSocketTimeout` was never set), so nearly every request burst dialed a brand-new connection and re-rolled the dice on the broken network path. Timeouts then triggered instant retries and a broken batch-split failover, so the client's own connection churn kept re-triggering the network fault.

## Changes

- **`eth/http.ts`** — pass `freeSocketTimeout` (new config, default **300 000 ms**) to the keep-alive agent so one warm connection persists across request bursts; honor the configured `maxSockets` (was hardcoded `256`).
- **`config.ts` / `index.ts`** — expose `eth.http.freeSocketTimeout` with docs; add it to `DEFAULT_CONFIG`.
- **`utils/obj.ts`** — `chunkArray` no longer mutates its input (`splice` → `slice`). The batch-split failover in `batchRequestWithFailover` re-chunked the array its own first attempt had already emptied: "Splitting batch into 2 chunks" chunked **zero** items, sent nothing, and resolved with an empty response set that `retry()` treated as success — silently skipping the remaining retry attempts and degrading every failed batch to the sequential single-request fallback. Log-visible as `expected response not found` + `Unprocessed batch request after receiving results` in the same millisecond as the split.
- **`eth/client.ts`** — guard `batchRequestWithFailover` against empty request sets; retry backoff `min: 0 → 500ms` (an instant retry lands on the same failing connection state that just timed out and only amplifies outages).
- **Tests** — add `chunkArray` regression tests (non-mutation, sizing, invalid chunk sizes); repair pre-existing compile errors in `test/abi/contract.test.ts` and `test/abi/repo.test.ts` left behind by the 0.0.70 constructor changes (`AbiRepository`/`Classification`/`EthereumClient` required params, `classifyContract` object arg, `TransactionLog` shape).

Version bumped to **0.0.71** (companion agentindex-api change depends on `^0.0.71` and is waiting on this publish).

## Verification

- `yarn build:ts` clean (wasm build not run on this machine — no Rust/wasm changes in this PR).
- `yarn test`: **12/12 suites, 36 tests, 92 snapshots passing** (the suite was 2 suites red before this PR due to the stale test signatures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
